### PR TITLE
fix: History Requires Refresh (#1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
         />
       )}
 
-      <HistoryPanel adapter={gameAdapter} />
+      <HistoryPanel />
 
       <DevTools onFill={fillCategories} onClear={reset} />
     </div>

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,37 +1,16 @@
-import { useState, useEffect } from 'react'
-import { Game, GameRepository } from '../types'
+import useGameStore from '../stores/gameStore'
 
-interface HistoryPanelProps {
-  adapter: GameRepository;
-}
-
-export default function HistoryPanel({ adapter }: HistoryPanelProps) {
-  const [games, setGames] = useState<Game[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    async function loadHistory() {
-      try {
-        const history = await adapter.list({ status: 'completed' })
-        // Newest first
-        setGames(history.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()))
-      } finally {
-        setLoading(false)
-      }
-    }
-    loadHistory()
-  }, [adapter])
-
-  if (loading) return null
+export default function HistoryPanel() {
+  const games = useGameStore(s => s.history)
 
   return (
     <div className="history-panel">
       <h2 className="history-title">History</h2>
-      {games?.length === 0 ? (
+      {!games || games.length === 0 ? (
         <p className="history-empty">No past games yet</p>
       ) : (
         <div className="history-list">
-          {games?.map(game => {
+          {games.map(game => {
             const date = new Date(game.createdAt)
             const isValidDate = !isNaN(date.getTime())
             const dateString = isValidDate ? date.toLocaleDateString() : 'Unknown Date'

--- a/src/storage/implementations/LocalGameAdapter.ts
+++ b/src/storage/implementations/LocalGameAdapter.ts
@@ -16,6 +16,19 @@ function saveAll(games: Game[]): void {
 }
 
 export class LocalGameAdapter {
+  private listeners = new Set<() => void>();
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private notify(): void {
+    this.listeners.forEach(l => l())
+  }
+
   async save(game: Game): Promise<Game> {
     const all = loadAll()
     const index = all.findIndex(g => g.id === game.id)
@@ -25,6 +38,7 @@ export class LocalGameAdapter {
       all.push(game)
     }
     saveAll(all)
+    this.notify()
     return game
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface GameRepository {
   save(game: Game): Promise<Game>;
   get(id: string): Promise<Game | undefined>;
   list(filter?: { status?: string }): Promise<Game[]>;
+  subscribe?(listener: () => void): () => void;
 }
 
 export interface LibraryItem {


### PR DESCRIPTION
This PR addresses Issue #1 by implementing a **Reactive Store architecture (Option 3)**.

### Key Changes
- **Repository Layer:** Added a `subscribe` method to `GameRepository` and `LocalGameAdapter`. It now notifies listeners whenever a game is saved to `localStorage`.
- **Store Layer:** `gameStore` now manages a `history` state. It subscribes to the adapter upon creation and automatically reloads the history when any part of the app (like `finishGame`) saves data.
- **UI Layer:** `HistoryPanel` is now a "dumb" component that reads directly from the `gameStore`. This removes the need for manual refreshes or complex component-level state.
- **Tests:** Updated and expanded tests in `HistoryPanel.test.tsx` and `gameStore.persistence.test.ts` to verify the reactive flow.

### Verification
- 69 total tests passing.
- Verified that completing a game instantly updates the history view.